### PR TITLE
fixed the layout shift issue

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,6 +12,10 @@ body {
     font-family: Arial, Helvetica, sans-serif;
 }
 
+body[data-scroll-locked] {
+    margin: 0 !important;
+}
+
 @layer utilities {
     .text-balance {
         text-wrap: balance;
@@ -46,6 +50,7 @@ body {
         --chart-5: 27 87% 67%;
         --radius: 0.5rem;
     }
+
     .dark {
         --background: 240 10% 3.9%;
         --foreground: 0 0% 98%;
@@ -78,12 +83,15 @@ body {
     * {
         @apply border-border;
     }
+
     body {
         @apply bg-background text-foreground;
     }
+
     h1 {
         @apply scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl;
     }
+
     h2 {
         @apply scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0;
     }


### PR DESCRIPTION
# Description
The layout shift when clicking the profile icon was caused by this CSS style.
```css
body[data-scroll-locked] {
    overflow: hidden !important;
    overscroll-behavior: contain;
    position: relative !important;
    padding-left: 0px;
    padding-top: 0px;
    padding-right: 0px;
    margin-left: 0;
    margin-top: 0;
    margin-right: 17px !important;
}
```
 which is added by a library I am unaware of, to prevent this issue a  CSS style is added to the global style CSS file.

## Type of change

- Bug fix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
